### PR TITLE
Calculate reverse lookups to reduce risk of mistakes

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -395,13 +395,7 @@ function Arena:update(dt)
             gold = 3
             passives = {}
             main_song_instance:stop()
-            run_passive_pool_by_tiers = {
-              [1] = { 'wall_echo', 'wall_rider', 'centipede', 'temporal_chains', 'amplify', 'amplify_x', 'ballista', 'ballista_x', 'blunt_arrow', 'berserking', 'unwavering_stance', 'assassination', 'unleash', 'blessing',
-                'hex_master', 'force_push', 'spawning_pool'}, 
-              [2] = {'ouroboros_technique_r', 'ouroboros_technique_l', 'intimidation', 'vulnerability', 'resonance', 'point_blank', 'longshot', 'explosive_arrow', 'chronomancy', 'awakening', 'ultimatum', 'echo_barrage', 
-                'reinforce', 'payback', 'whispers_of_doom', 'heavy_impact', 'immolation', 'call_of_the_void'},
-              [3] = {'divine_machine_arrow', 'divine_punishment', 'flying_daggers', 'crucio', 'hive', 'void_rift'},
-            }
+            run_passive_pool_by_tiers = table.shallow_copy(tier_to_passives)
             max_units = 7 + current_new_game_plus
             main:add(BuyScreen'buy_screen')
             locked_state = nil
@@ -575,13 +569,7 @@ function Arena:update(dt)
         gold = 3
         passives = {}
         main_song_instance:stop()
-        run_passive_pool_by_tiers = {
-          [1] = { 'wall_echo', 'wall_rider', 'centipede', 'temporal_chains', 'amplify', 'amplify_x', 'ballista', 'ballista_x', 'blunt_arrow', 'berserking', 'unwavering_stance', 'assassination', 'unleash', 'blessing',
-            'hex_master', 'force_push', 'spawning_pool'}, 
-          [2] = {'ouroboros_technique_r', 'ouroboros_technique_l', 'intimidation', 'vulnerability', 'resonance', 'point_blank', 'longshot', 'explosive_arrow', 'chronomancy', 'awakening', 'ultimatum', 'echo_barrage', 
-            'reinforce', 'payback', 'whispers_of_doom', 'heavy_impact', 'immolation', 'call_of_the_void'},
-          [3] = {'divine_machine_arrow', 'divine_punishment', 'flying_daggers', 'crucio', 'hive', 'void_rift'},
-        }
+        run_passive_pool_by_tiers = table.shallow_copy(tier_to_passives)
         max_units = 7 + current_new_game_plus
         main:add(BuyScreen'buy_screen')
         locked_state = nil
@@ -994,13 +982,7 @@ function Arena:die()
           gold = 3
           passives = {}
           main_song_instance:stop()
-          run_passive_pool_by_tiers = {
-            [1] = { 'wall_echo', 'wall_rider', 'centipede', 'temporal_chains', 'amplify', 'amplify_x', 'ballista', 'ballista_x', 'blunt_arrow', 'berserking', 'unwavering_stance', 'assassination', 'unleash', 'blessing',
-              'hex_master', 'force_push', 'spawning_pool'}, 
-            [2] = {'ouroboros_technique_r', 'ouroboros_technique_l', 'intimidation', 'vulnerability', 'resonance', 'point_blank', 'longshot', 'explosive_arrow', 'chronomancy', 'awakening', 'ultimatum', 'echo_barrage', 
-              'reinforce', 'payback', 'whispers_of_doom', 'heavy_impact', 'immolation', 'call_of_the_void'},
-            [3] = {'divine_machine_arrow', 'divine_punishment', 'flying_daggers', 'crucio', 'hive', 'void_rift'},
-          }
+          run_passive_pool_by_tiers = table.shallow_copy(tier_to_passives)
           max_units = 7 + current_new_game_plus
           main:add(BuyScreen'buy_screen')
           system.save_run()

--- a/buy_screen.lua
+++ b/buy_screen.lua
@@ -142,13 +142,7 @@ function BuyScreen:on_enter(from, level, units, passives, shop_level, shop_xp)
       gold = 3
       passives = {}
       main_song_instance:stop()
-      run_passive_pool_by_tiers = {
-        [1] = {'wall_echo', 'wall_rider', 'centipede', 'temporal_chains', 'amplify', 'amplify_x', 'ballista', 'ballista_x', 'blunt_arrow', 'berserking', 'unwavering_stance', 'assassination', 'unleash', 'blessing',
-          'hex_master', 'force_push', 'spawning_pool'}, 
-        [2] = {'ouroboros_technique_r', 'ouroboros_technique_l', 'intimidation', 'vulnerability', 'resonance', 'point_blank', 'longshot', 'explosive_arrow', 'chronomancy', 'awakening', 'ultimatum', 'echo_barrage', 
-          'reinforce', 'payback', 'whispers_of_doom', 'heavy_impact', 'immolation', 'call_of_the_void'},
-        [3] = {'divine_machine_arrow', 'divine_punishment', 'flying_daggers', 'crucio', 'hive', 'void_rift'},
-      }
+      run_passive_pool_by_tiers = table.shallow_copy(tier_to_passives)
       max_units = 7 + current_new_game_plus
       main:add(BuyScreen'buy_screen')
       system.save_run()
@@ -526,13 +520,7 @@ function RestartButton:update(dt)
       gold = 3
       passives = {}
       main_song_instance:stop()
-      run_passive_pool_by_tiers = {
-        [1] = { 'wall_echo', 'wall_rider', 'centipede', 'temporal_chains', 'amplify', 'amplify_x', 'ballista', 'ballista_x', 'blunt_arrow', 'berserking', 'unwavering_stance', 'assassination', 'unleash', 'blessing',
-          'hex_master', 'force_push', 'spawning_pool'}, 
-        [2] = {'ouroboros_technique_r', 'ouroboros_technique_l', 'intimidation', 'vulnerability', 'resonance', 'point_blank', 'longshot', 'explosive_arrow', 'chronomancy', 'awakening', 'ultimatum', 'echo_barrage', 
-          'reinforce', 'payback', 'whispers_of_doom', 'heavy_impact', 'immolation', 'call_of_the_void'},
-        [3] = {'divine_machine_arrow', 'divine_punishment', 'flying_daggers', 'crucio', 'hive', 'void_rift'},
-      }
+      run_passive_pool_by_tiers = table.shallow_copy(tier_to_passives)
       system.save_state()
       main:add(BuyScreen'buy_screen')
       system.save_run()

--- a/main.lua
+++ b/main.lua
@@ -923,13 +923,6 @@ function init()
     ['mercenary'] = function(lvl) return '[' .. ylb1(lvl) .. ']2[' .. ylb2(lvl) .. ']/4 [fg]- [' .. ylb1(lvl) .. ']+10%[' .. ylb2(lvl) .. ']/+20% [fg]chance for enemies to drop gold on death' end,
   }
 
-  tier_to_characters = {
-    [1] = {'vagrant', 'swordsman', 'magician', 'archer', 'scout', 'cleric', 'arcanist', 'miner'},
-    [2] = {'wizard', 'saboteur', 'sage', 'squire', 'dual_gunner', 'hunter', 'chronomancer', 'barbarian', 'cryomancer', 'beastmaster', 'jester', 'carver', 'psychic', 'witch', 'silencer', 'outlaw', 'merchant'},
-    [3] = {'elementor', 'stormweaver', 'spellblade', 'psykeeper', 'engineer', 'juggernaut', 'pyromancer', 'host', 'assassin', 'bane', 'barrager', 'infestor', 'flagellant', 'illusionist', 'usurer', 'gambler'},
-    [4] = {'priest', 'highlander', 'psykino', 'fairy', 'blade', 'plague_doctor', 'cannoneer', 'vulcanist', 'warden', 'corruptor', 'thief'},
-  }
-
   non_attacking_characters = {'cleric', 'stormweaver', 'squire', 'chronomancer', 'sage', 'psykeeper', 'bane', 'carver', 'fairy', 'priest', 'flagellant', 'merchant', 'miner'}
   non_cooldown_characters = {'squire', 'chronomancer', 'psykeeper', 'merchant', 'miner'}
 
@@ -989,6 +982,12 @@ function init()
     ['gambler'] = 3,
     ['thief'] = 4,
   }
+
+  tier_to_characters = { {}, {}, {}, {} } -- max tier 4
+  for k, v in pairs(character_tiers) do
+    table.insert(tier_to_characters[v], k)
+  end
+
 
   get_number_of_units_per_class = function(units)
     local rangers = 0
@@ -1227,13 +1226,10 @@ function init()
     ['void_rift'] = 3,
   }
 
-  tier_to_passives = {
-    [1] = {'wall_echo', 'wall_rider', 'centipede', 'temporal_chains', 'amplify', 'amplify_x', 'ballista', 'ballista_x', 'blunt_arrow', 'berserking', 'unwavering_stance', 'assassination', 'unleash', 'blessing',
-      'hex_master', 'force_push', 'spawning_pool'},
-    [2] = {'ouroboros_technique_r', 'ouroboros_technique_l', 'intimidation', 'vulnerability', 'resonance', 'point_blank', 'longshot', 'explosive_arrow', 'chronomancy', 'awakening', 'ultimatum', 'echo_barrage',
-      'reinforce', 'payback', 'whispers_of_doom', 'heavy_impact', 'immolation', 'call_of_the_void'},
-    [3] = {'divine_machine_arrow', 'divine_punishment', 'flying_daggers', 'crucio', 'hive', 'void_rift'},
-  }
+  tier_to_passives = { {}, {}, {} } -- max tier 3
+  for k,v in pairs(passive_tiers) do
+    table.insert(tier_to_passives[v], k)
+  end
 
   level_to_tier_weights = {
     [1] = {90, 10, 0, 0},
@@ -1435,13 +1431,7 @@ function init()
   end
 
   local run = system.load_run()
-  run_passive_pool_by_tiers = run.run_passive_pool_by_tiers or {
-    [1] = { 'wall_echo', 'wall_rider', 'centipede', 'temporal_chains', 'amplify', 'amplify_x', 'ballista', 'ballista_x', 'blunt_arrow', 'berserking', 'unwavering_stance', 'assassination', 'unleash', 'blessing',
-      'hex_master', 'force_push', 'spawning_pool'}, 
-    [2] = {'ouroboros_technique_r', 'ouroboros_technique_l', 'intimidation', 'vulnerability', 'resonance', 'point_blank', 'longshot', 'explosive_arrow', 'chronomancy', 'awakening', 'ultimatum', 'echo_barrage', 
-      'reinforce', 'payback', 'whispers_of_doom', 'heavy_impact', 'immolation', 'call_of_the_void'},
-    [3] = {'divine_machine_arrow', 'divine_punishment', 'flying_daggers', 'crucio', 'hive', 'void_rift'},
-  }
+  run_passive_pool_by_tiers = run.run_passive_pool_by_tiers or table.shallow_copy(tier_to_passives)
   gold = run.gold or 3
   passives = run.passives or {}
   locked_state = run.locked_state


### PR DESCRIPTION
The reverse lookup for items had some wrong values:
* `amplify_x` and `ballista_x` where both marked as **tier 2** items, but was sorted into the **tier 1** reverse lookup.
* `resonance` was marked as a **tier 3** item, but was sorted into the **tier 2** reverse lookup.
* `magnify` was marked as a **tier 1** item, but was not in any reverse lookup.

I modified the code to automatically calculate the reverse lookups. The ordering is not important, since it is just used for random sampling.

The reverse lookup for characters was ok, but I did the same there to reduce risk of mistakes in the future.

I replaced all instances of literal copies of `tier_to_passives` (named `run_passive_pool_by_tiers`) with cloning of `tier_to_passives` instead.

![image](https://user-images.githubusercontent.com/277403/120939477-981b4a80-c718-11eb-9e11-2a10b6a7a464.png)
