### PR TITLE
Add cursor grab on game start

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1917,6 +1917,7 @@ end
 
 
 function love.run()
+  love.mouse.setGrabbed(true)
   return engine_run({
     game_name = 'SNKRX',
     window_width = 'max',


### PR DESCRIPTION
Added grabbing of cursor to the game to have behaviour matching borderless window.
Without this multi-monitor setups would ruin the game experience due to the cursor leaving the game screen.
This pull request prevents this.

Couldn't do any in-game testing as just cloning and running the game had issues but I got it to work in the main menu, couldn't test for any side-effects though.