### PR TITLE
Fix aspd buffing v1

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1016,9 +1016,10 @@ function init()
     [4] = {'priest', 'highlander', 'psykino', 'fairy', 'blade', 'plague_doctor', 'cannoneer', 'vulcanist', 'warden', 'corruptor', 'thief'},
   }
 
-  non_attacking_characters = {'cleric', 'stormweaver', 'squire', 'chronomancer', 'sage', 'psykeeper', 'bane', 'carver', 'fairy', 'priest', 'flagellant', 'merchant', 'miner'}
-  non_cooldown_characters = {'squire', 'chronomancer', 'psykeeper', 'merchant', 'miner'}
-
+  non_attacking_characters = {'cleric', 'stormweaver', 'squire', 'chronomancer', 'sage', 'bane', 'carver', 'fairy', 'priest', 'merchant', 'miner', 'infestor', 'jester', 'silencer', 'warden'}
+  non_cooldown_characters = {'squire', 'chronomancer', 'psykeeper', 'merchant', 'miner', 'cryomancer', 'pyromancer'}
+  non_speed_buffable = {'artificer', 'bomber', 'carver', 'chronomancer', 'cleric', 'cryomancer', 'engineer', 'fairy', 'flagellant', 'host', 'merchant', 'miner', 'priest', 'psykeeper', 'pyromancer', 'sentry', 'squire', 'stormweaver', 'vulcanist', 'warden'}
+  
   character_tiers = {
     ['vagrant'] = 1,
     ['swordsman'] = 1,

--- a/player.lua
+++ b/player.lua
@@ -1718,7 +1718,7 @@ end
 
 
 function Player:is_attacker(unit)
-  return table.all(non_attacking_characters, function(v) return v ~= unit.character end)
+  return table.all(non_speed_buffable, function(v) return v ~= unit.character end)
 end
 
 


### PR DESCRIPTION
This fix addresses 2 points that still prevent aspd buffs from selecting the correct character.

1. The extremely low but still present chance that a valid character is not chosen at random from the list of units even after 1000 tries. Now an eligible character will always get chosen without even needing to retry.
2. The list used to detect ineligible characters was repurposed from other code. That list is for characters who cannot safely do damage on their own and so should not appear as the only selections on the buy screen. For example on that list is the 'sage' which cannot do damage (until level 3) but would charge faster with an aspd buff. Now a new list has been added to determine which characters should receive an aspd buff. Additionally, the list of non cooldown and non attacking characters have been updated against the current characters in the game.

I'm also pushing an alternate v2 of this fix, that does the same thing but a bit more efficiently. Instead of lookup tables, it uses variables set for each character in the Player:init section. You can decide which approach, if any, you prefer. This also gave me a chance to learn about basic branching in Git, I hope you don't mind.